### PR TITLE
Include local certificate

### DIFF
--- a/modules/local_domain/default.nix
+++ b/modules/local_domain/default.nix
@@ -58,6 +58,8 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.dnsmasq cfg.nginx ];
 
+    security.pki.certificateFiles = [ ./cert/fabriq.test.crt ];
+
     launchd.daemons.dnsmasq = {
       path = [ cfg.dnsmasq ];
       serviceConfig = {


### PR DESCRIPTION
Before this commit, running `curl https://acme.fabriq.test` would result in the following error: `error:16000069:STORE routines::unregistered scheme`.

This is because the self-signed certificate for *.fabriq.test has not been included in the system's CA bundle.

This commit fixes it.